### PR TITLE
Split coverage update workflow off of the main reusable workflow

### DIFF
--- a/.github/workflows/reusable-node-ci.yml
+++ b/.github/workflows/reusable-node-ci.yml
@@ -245,24 +245,3 @@ jobs:
               exit 0
             fi
           fi
-
-      - name: Update Jest config with coverage
-        id: update_coverage
-        if: steps.check_coverage.outcome == 'success'
-        run: |
-          echo "Running posttest (jest-it-up) now..." 
-          npm run posttest
-
-      - name: Commit Jest-it-up changes (if applicable)
-        id: commit_coverage_updates
-        if: steps.update_coverage.outcome == 'success'
-        run: |
-          echo "Committing jest-it-up changes..."
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add jest.config.js
-          git commit -m "chore: update coverage thresholds with jest-it-up" || echo "No changes to commit"
-
-      - name: Push changes
-        if: steps.commit_coverage_updates.outcome == 'success'
-        run: git push || echo "No changes to push"

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -1,0 +1,46 @@
+name: Post-Merge Coverage Update
+# This should be installed in any repo where you wish to automatically update code coverage.
+# This assumes you have configured posttest to run jest-it-up and test:coverage configured to run
+# jest with coverage. This will run on all pushes to the dev branch and assumes the unit tests will pass.
+on:
+  push:
+    branches:
+      - dev
+env:
+  NODE_VERSION: ${{ vars.NODE_VERSION }}
+  RUST_VERSION: ${{ vars.RUST_VERSION }}
+jobs:
+  update-jest-it-up:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          ref: dev
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4.0.0
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Set up Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ env.RUST_VERSION }}
+          override: true
+
+      - name: Install dependencies and check coverage
+        run: |
+          npm ci
+          npm run test:coverage
+          npm run posttest
+
+      - name: Check for config changes
+        id: check_for_changes
+        run: |
+          git config --global user.name "GitHub Actions"
+          git config --global user.email "actions@github.com"
+          git diff --quiet || git commit -am "chore: Update coverage thresholds"
+          git push
+


### PR DESCRIPTION
This can theoretically be tested before merging it to dev but realistically it only runs when code is getting pushed to dev :D 

The way this is setup, everything with the generic CI will attempt to run unit tests and will run coverage to validate that before the workflow can pass. Anything where we want to automatically update the jest config with new coverage levels will need the new workflow copied into it. I didn't make it reusable since it will only contain this one thing so if we make any major changes to it, those will need to be ported anywhere that's running this workflow.