### PR TITLE
fix: use o1 since we dont have o3-mini api access

### DIFF
--- a/.github/workflows/reusable-node-ci.yml
+++ b/.github/workflows/reusable-node-ci.yml
@@ -66,7 +66,7 @@ jobs:
         env:
           OPENAI_KEY: ${{ secrets.OPENAI_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          config.model: "o3-mini"
+          config.model: "o1"
           config.custom_reasoning_model: "true"
           pr_code_suggestions.commitable_code_suggestions: "true"
           pr_reviewer.require_score_review: "true"


### PR DESCRIPTION
### **PR Type**
configuration changes


___

### **Description**
- Updated `config.model` in reusable Node CI workflow to use `o1` instead of `o3-mini`.

- Maintains current configuration with minor adaptation for compatibility.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>reusable-node-ci.yml</strong><dd><code>Updated `config.model` to use `o1` in CI configuration</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/reusable-node-ci.yml

<li>Changed the value of <code>config.model</code> from <code>o3-mini</code> to <code>o1</code>.<br> <li> Ensures compatibility with the absence of <code>o3-mini</code> API access.


</details>


  </td>
  <td><a href="https://github.com/shardeum/github-automation/pull/58/files#diff-296285c6e1955afc95fbcd488e81a37199cb1b68798b218f9400a4f56940fb2b">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>